### PR TITLE
fix: correct HTTP status codes for upload limit errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,10 +360,10 @@ Controls HTTP request logging (Morgan). Enabled by default (`dev` format). Set t
 }
 ```
 
-| Option   | Default      | Description                                                    |
-| -------- | ------------ | -------------------------------------------------------------- |
-| `format` | `"combined"` | Morgan format: `combined`, `common`, `dev`, `short`, or `tiny` |
-| `file`   | none         | Path to log file (relative to config file). Appended if exists |
+| Option   | Default                                 | Description                                                                                                                    |
+| -------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `format` | `"dev"` (console) / `"combined"` (file) | Morgan format: `combined`, `common`, `dev`, `short`, or `tiny`. Defaults to `"combined"` when `file` is set, `"dev"` otherwise |
+| `file`   | none                                    | Path to log file (relative to config file). Appended if exists                                                                 |
 
 When `file` is set, logs are written to the file only (not to the console).
 

--- a/cypress/e2e/features.cy.js
+++ b/cypress/e2e/features.cy.js
@@ -171,4 +171,20 @@ describe('upload', () => {
       expect(res.body.error).to.be.a('string');
     });
   });
+
+  it('returns 400 when field name does not match fieldName (LIMIT_UNEXPECTED_FILE)', () => {
+    const strictUrl = 'http://localhost:8086/upload-strict';
+    // fieldName is "file"; sending under "data" triggers LIMIT_UNEXPECTED_FILE
+    const body = `--${boundary}\r\nContent-Disposition: form-data; name="data"; filename="test.txt"\r\nContent-Type: text/plain\r\n\r\nhello\r\n--${boundary}--`;
+    cy.request({
+      method: 'POST',
+      url: strictUrl,
+      headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
+      body,
+      failOnStatusCode: false,
+    }).then((res) => {
+      expect(res.status).to.eq(400);
+      expect(res.body.error).to.be.a('string');
+    });
+  });
 });

--- a/cypress/e2e/features.cy.js
+++ b/cypress/e2e/features.cy.js
@@ -100,3 +100,75 @@ describe('rateLimit', () => {
     });
   });
 });
+
+describe('upload', () => {
+  const url = 'http://localhost:8086/upload';
+  const boundary = '----TestBoundary123';
+
+  function multipart(files) {
+    return files
+      .map(
+        ({ name, content, type }) =>
+          `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${name}"\r\nContent-Type: ${type}\r\n\r\n${content}`,
+      )
+      .join('\r\n')
+      .concat(`\r\n--${boundary}--`);
+  }
+
+  it('returns 200 with file info on valid upload', () => {
+    cy.request({
+      method: 'POST',
+      url,
+      headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
+      body: multipart([{ name: 'test.txt', content: 'hello', type: 'text/plain' }]),
+      failOnStatusCode: false,
+    }).then((res) => {
+      expect(res.status).to.eq(200);
+      expect(res.body.files).to.have.length(1);
+      expect(res.body.files[0].originalName).to.eq('test.txt');
+    });
+  });
+
+  it('returns 413 when file exceeds maxFileSize (1024 bytes)', () => {
+    cy.request({
+      method: 'POST',
+      url,
+      headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
+      body: multipart([{ name: 'big.txt', content: 'x'.repeat(2048), type: 'text/plain' }]),
+      failOnStatusCode: false,
+    }).then((res) => {
+      expect(res.status).to.eq(413);
+      expect(res.body.error).to.be.a('string');
+    });
+  });
+
+  it('returns 400 when number of files exceeds maxFiles (2)', () => {
+    cy.request({
+      method: 'POST',
+      url,
+      headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
+      body: multipart([
+        { name: 'a.txt', content: 'a', type: 'text/plain' },
+        { name: 'b.txt', content: 'b', type: 'text/plain' },
+        { name: 'c.txt', content: 'c', type: 'text/plain' },
+      ]),
+      failOnStatusCode: false,
+    }).then((res) => {
+      expect(res.status).to.eq(400);
+      expect(res.body.error).to.be.a('string');
+    });
+  });
+
+  it('returns 400 when file type is not in allowedTypes', () => {
+    cy.request({
+      method: 'POST',
+      url,
+      headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
+      body: multipart([{ name: 'img.png', content: 'fakepng', type: 'image/png' }]),
+      failOnStatusCode: false,
+    }).then((res) => {
+      expect(res.status).to.eq(400);
+      expect(res.body.error).to.be.a('string');
+    });
+  });
+});

--- a/demo/server-config.json
+++ b/demo/server-config.json
@@ -60,12 +60,19 @@
   },
   {
     "port": 8086,
-    "upload": {
-      "path": "/upload",
-      "dir": "./demo/uploads",
-      "maxFileSize": 1024,
-      "maxFiles": 2,
-      "allowedTypes": ["text/plain"]
-    }
+    "upload": [
+      {
+        "path": "/upload",
+        "dir": "./uploads",
+        "maxFileSize": 1024,
+        "maxFiles": 2,
+        "allowedTypes": ["text/plain"]
+      },
+      {
+        "path": "/upload-strict",
+        "dir": "./uploads-strict",
+        "fieldName": "file"
+      }
+    ]
   }
 ]

--- a/demo/server-config.json
+++ b/demo/server-config.json
@@ -57,5 +57,15 @@
   {
     "port": 8085,
     "proxy": [["http://localhost:4001", "http://localhost:4002"]]
+  },
+  {
+    "port": 8086,
+    "upload": {
+      "path": "/upload",
+      "dir": "./demo/uploads",
+      "maxFileSize": 1024,
+      "maxFiles": 2,
+      "allowedTypes": ["text/plain"]
+    }
   }
 ]

--- a/server.js
+++ b/server.js
@@ -556,7 +556,14 @@ function setupUpload(router, siteConfig, configDir) {
       ? uploader.array(uploadConfig.fieldName)
       : uploader.any();
 
-    router.post(uploadUrlPath, multerMiddleware, handleUploadResponse);
+    router.post(uploadUrlPath, (req, res, next) => {
+      multerMiddleware(req, res, (err) => {
+        if (err?.code === 'LIMIT_FILE_SIZE') return res.status(413).json({ error: err.message });
+        if (err?.code === 'LIMIT_FILE_COUNT') return res.status(400).json({ error: err.message });
+        if (err) return next(err);
+        handleUploadResponse(req, res);
+      });
+    });
     router.use(uploadUrlPath, express.static(uploadDir));
     console.log(`[upload] POST ${uploadUrlPath} → ${uploadDir}`);
   }

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawn, spawnSync } from 'node:child_process';
+import { randomInt } from 'node:crypto';
 import fs from 'node:fs';
 import https from 'node:https';
 import path from 'node:path';
@@ -543,7 +544,7 @@ function setupUpload(router, siteConfig, configDir) {
         const ext = path.extname(file.originalname);
         const base =
           path.basename(file.originalname, ext).replaceAll(/[^a-zA-Z0-9_.-]/g, '_') || 'file';
-        cb(null, `${base}-${Date.now()}-${Math.round(Math.random() * 1e9)}${ext}`);
+        cb(null, `${base}-${Date.now()}-${randomInt(0, 1_000_000_000)}${ext}`);
       },
     });
 
@@ -560,6 +561,9 @@ function setupUpload(router, siteConfig, configDir) {
       multerMiddleware(req, res, (err) => {
         if (err?.code === 'LIMIT_FILE_SIZE') return res.status(413).json({ error: err.message });
         if (err?.code === 'LIMIT_FILE_COUNT') return res.status(400).json({ error: err.message });
+        if (err?.status || err?.statusCode) {
+          return res.status(err.statusCode || err.status).json({ error: err.message });
+        }
         if (err) return next(err);
         handleUploadResponse(req, res);
       });

--- a/server.js
+++ b/server.js
@@ -559,13 +559,15 @@ function setupUpload(router, siteConfig, configDir) {
 
     router.post(uploadUrlPath, (req, res, next) => {
       multerMiddleware(req, res, (err) => {
-        if (err?.code === 'LIMIT_FILE_SIZE') return res.status(413).json({ error: err.message });
-        if (err?.code === 'LIMIT_FILE_COUNT') return res.status(400).json({ error: err.message });
+        if (err instanceof multer.MulterError) {
+          const status = err.code === 'LIMIT_FILE_SIZE' ? 413 : 400;
+          return res.status(status).json({ error: err.message });
+        }
         if (err?.status || err?.statusCode) {
           return res.status(err.statusCode || err.status).json({ error: err.message });
         }
         if (err) return next(err);
-        handleUploadResponse(req, res);
+        return handleUploadResponse(req, res);
       });
     });
     router.use(uploadUrlPath, express.static(uploadDir));


### PR DESCRIPTION
## Summary

- `LIMIT_FILE_SIZE` (multer) now returns **413** instead of 500
- `LIMIT_FILE_COUNT` (multer) now returns **400** instead of 500
- Docs fix: `logging.format` default clarified — `"dev"` when no `file` is set, `"combined"` when `file` is set

## Root cause

`MulterError` has no `status`/`statusCode` property, so Express's default error handler was returning 500 for both limit violations. Fixed by wrapping `multerMiddleware` in a callback and mapping `err.code` to the correct HTTP status before responding.

## Test plan

- [ ] POST a file exceeding `maxFileSize` → expect 413
- [ ] POST more files than `maxFiles` → expect 400
- [ ] POST a disallowed MIME type (`allowedTypes`) → expect 400 (unchanged)
- [ ] Normal upload → expect 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified logging configuration defaults and format behavior in README.

* **Bug Fixes**
  * Upload error handling now returns appropriate HTTP statuses and JSON error messages for size, count, validation and processing errors.

* **New Features**
  * Improved uploaded file naming with stronger randomness.
  * Added a demo server configuration exposing local upload endpoints with configurable size, count and type constraints.

* **Tests**
  * Added end-to-end tests covering successful uploads and failure scenarios (oversize, too many files, disallowed types, unexpected form fields).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->